### PR TITLE
ENH: Update extension metadata

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,10 +4,10 @@ project(BreastImplantAnalyzer)
 
 #-----------------------------------------------------------------------------
 # Extension meta-information
-set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerBreastImplantAnalyzer")
+set(EXTENSION_HOMEPAGE "https://github.com/lassoan/SlicerBreastImplantAnalyzer#breastimplantanalyzer")
 set(EXTENSION_CATEGORY "Quantification")
-set(EXTENSION_CONTRIBUTORS "Lance Levine (University of Miami Miller School of Medicine), Marc Levine, Dr. Wrood Kassira (University of Miami Department of Plastic Surgery)")
-set(EXTENSION_DESCRIPTION "A 3D Slicer extension for analyzing volume of breast implants.")
+set(EXTENSION_CONTRIBUTORS "Lance Levine (University of Miami Miller School of Medicine), Marc Levine (Penn State University College of Medicine), Dr. Wrood Kassira (University of Miami Department of Plastic & Reconstructive Surgery)")
+set(EXTENSION_DESCRIPTION "This extension allows the user to calculate the volume of a breast implant from breast MRI data with minimal user input.")
 set(EXTENSION_ICONURL "https://raw.githubusercontent.com/lancelevine/SlicerBreastImplantAnalyzer/master/BreastImplantAnalyzer.png")
 set(EXTENSION_SCREENSHOTURLS "https://raw.githubusercontent.com/lancelevine/SlicerBreastImplantAnalyzer/master/Screenshot01.PNG")
 set(EXTENSION_DEPENDS "NA") # Specified as a list or "NA" if no dependencies


### PR DESCRIPTION
Consolidate extension metadata based on the corresponding s4ext file organized
in the ExtensionsIndex repository.